### PR TITLE
Travis Config Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ addons:
     packages:
       - sox
       - libsox-fmt-all
+branches:
+  only:
+    - master


### PR DESCRIPTION
Anytime a branch is pushed to GitHub, Travis CI will kick off a build even though it isn't necessarily ready for one yet. This makes it so those branches aren't built until a pull request is made.