### PR TITLE
Fixed readme typo in stop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Stop the playback (without the ability to resume later) by using the `stop` func
 
 ```javascript
 troubadour.on('stop', () => {
-  // Do something here when the audio is paused
+  // Do something here when the audio is stopped
 });
 
 troubadour.stop();


### PR DESCRIPTION
Updated the readme to fix a typo in the stop documentation.

Fixes issue #24.